### PR TITLE
Don't allow failures on Trunk any longer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,3 @@ smalltalk:
   - Squeak-trunk
   - Squeak-5.2
   - Squeak-5.1
-  
-matrix:
-  allow_failures:
-    - smalltalk: Squeak-trunk


### PR DESCRIPTION
After smalltalkCI has been fixed, now there should be no more reason to allow failures.